### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# VBA extensions - Don't perform LF normalization to avoid issues when downloading raw files. 
+*.bas    -text
+*.cls    -text
+*.frm    -text


### PR DESCRIPTION
I'd suggest making those changes to your .gitattributes file. 

This will ensure that if you upload vba code to GitHub and people try to download the raw file, they won't have issue when they try to import the file inside the VB editor.

![image](https://github.com/Jeomhps/Excel-lent-FZF/assets/31558169/8e2e6afa-bbe5-433a-bba8-bf882cc6e02a)

The reason why this is an issue is because the VB Editor can't deal with LF (Unix-style line endings) and expect the file to use CRLF (Windows-style line endings).